### PR TITLE
pom was missing the import of the maven-bundle-plugin created manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
               <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>


### PR DESCRIPTION
As per http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html "Adding OSGi metadata to existing projects without changing the packaging type", third part.
