### PR TITLE
Remove the default zone rules provider service declaration from no-tzdb jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
               <excludes>
                 <exclude>org/threeten/bp/*.dat</exclude>
                 <exclude>org/threeten/bp/zone/TzdbZoneRulesCompiler*</exclude>
+                <exclude>META-INF/services/org.threeten.bp.zone.ZoneRulesProvider</exclude>
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
Otherwise it tries to load the absent `TZDB.dat`.

Refs #29.