### PR TITLE
Add bounds check in StandardZoneRules#next/previousTransition()

### DIFF
--- a/src/main/java/org/threeten/bp/zone/StandardZoneRules.java
+++ b/src/main/java/org/threeten/bp/zone/StandardZoneRules.java
@@ -463,6 +463,10 @@ final class StandardZoneRules extends ZoneRules implements Serializable {
     //-----------------------------------------------------------------------
     @Override
     public ZoneOffsetTransition nextTransition(Instant instant) {
+        if (savingsInstantTransitions.length == 0) {
+            return null;
+        }
+        
         long epochSec = instant.getEpochSecond();
 
         // check if using last rules
@@ -498,6 +502,10 @@ final class StandardZoneRules extends ZoneRules implements Serializable {
 
     @Override
     public ZoneOffsetTransition previousTransition(Instant instant) {
+        if (savingsInstantTransitions.length == 0) {
+            return null;
+        }
+        
         long epochSec = instant.getEpochSecond();
         if (instant.getNano() > 0 && epochSec < Long.MAX_VALUE) {
             epochSec += 1;  // allow rest of method to only use seconds

--- a/src/test/java/org/threeten/bp/zone/TestStandardZoneRules.java
+++ b/src/test/java/org/threeten/bp/zone/TestStandardZoneRules.java
@@ -34,6 +34,7 @@ package org.threeten.bp.zone;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -91,6 +92,21 @@ public class TestStandardZoneRules {
         ZoneRules result = (ZoneRules) in.readObject();
 
         assertEquals(result, test);
+    }
+    
+    //-----------------------------------------------------------------------
+    // Etc/GMT
+    //-----------------------------------------------------------------------
+    private ZoneRules etcGmt() {
+        return ZoneId.of("Etc/GMT").getRules();
+    }
+    
+    public void test_EtcGmt_nextTransition() {
+        assertNull(etcGmt().nextTransition(Instant.EPOCH));
+    }
+
+    public void test_EtcGmt_previousTransition() {
+        assertNull(etcGmt().previousTransition(Instant.EPOCH));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Otherwise an ArrayIndexOutOfBoundsException will be thrown when no historic transitions are present.

Also include tests for ZoneRules#next/previousTransition() with sample affected zone.

References #34: Crash in StandardZoneRules#nextTransition()