### PR TITLE
Applied a bug fix from a more recent implementation of the Instant class

### DIFF
--- a/src/main/java/org/threeten/bp/Instant.java
+++ b/src/main/java/org/threeten/bp/Instant.java
@@ -1052,8 +1052,14 @@ public final class Instant
      * @throws ArithmeticException if numeric overflow occurs
      */
     public long toEpochMilli() {
-        long millis = Jdk8Methods.safeMultiply(seconds, 1000);
-        return millis + nanos / NANOS_PER_MILLI;
+        if (seconds < 0 && nanos > 0) {
+            long millis = Jdk8Methods.safeMultiply(seconds+1, 1000);
+            long adjustment = nanos / NANOS_PER_MILLI - 1000;
+            return millis + adjustment;
+        } else {
+            long millis = Jdk8Methods.safeMultiply(seconds, 1000);
+            return millis + nanos / NANOS_PER_MILLI;
+        }
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/bp/TestInstant.java
+++ b/src/test/java/org/threeten/bp/TestInstant.java
@@ -1402,6 +1402,26 @@ public class TestInstant extends AbstractDateTimeTest {
         Instant.ofEpochSecond(Long.MIN_VALUE / 1000 - 1).toEpochMilli();
     }
 
+
+    @DataProvider(name="sampleEpochMillis")
+    private Object[][] provider_sampleEpochMillis() {
+        return new Object[][] {
+                {"Long.MAX_VALUE", Long.MAX_VALUE},
+                {"Long.MAX_VALUE-1", Long.MAX_VALUE - 1},
+                {"1", 1L},
+                {"0", 0L},
+                {"-1", -1L},
+                {"Long.MIN_VALUE+1", Long.MIN_VALUE + 1},
+                {"Long.MIN_VALUE", Long.MIN_VALUE}
+        };
+    }
+    @Test(dataProvider="sampleEpochMillis")
+    public void test_epochMillis(String name, long millis) {
+        Instant t1 = Instant.ofEpochMilli(millis);
+        long m = t1.toEpochMilli();
+        assertEquals(millis, m, name);
+    }
+
     //-----------------------------------------------------------------------
     // compareTo()
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Due to a bug with the original Java 8 time implementation, times constructed from millisecond values less than -9223372036854775000 will throw an ArithmeticException when converted back to long representation.

This bug is documented here : https://bugs.openjdk.java.net/browse/JDK-8074032

There is a diff that fixed this issue linked in this bug report : http://hg.openjdk.java.net/jdk9/dev/jdk/rev/7c6d6f1b7a56

I have just adapted this bug fix for the backport.