### PR TITLE
Allow custom DateTimeTextProvider to be set as default

### DIFF
--- a/src/main/java/org/threeten/bp/format/DateTimeTextProvider.java
+++ b/src/main/java/org/threeten/bp/format/DateTimeTextProvider.java
@@ -48,13 +48,26 @@ import org.threeten.bp.temporal.TemporalField;
  */
 abstract class DateTimeTextProvider {
 
+    private static volatile DateTimeTextProvider INSTANCE;
+    private static final Object LOCK = new Object();
+
     /**
      * Gets the provider.
      *
      * @return the provider, not null
      */
     static DateTimeTextProvider getInstance() {
-        return new SimpleDateTimeTextProvider();
+        DateTimeTextProvider result = INSTANCE;
+        if (result == null) {
+            synchronized (LOCK) {
+                result = INSTANCE;
+                if (result == null) {
+                    result = new SimpleDateTimeTextProvider();
+                    INSTANCE = result;
+                }
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/threeten/bp/format/DateTimeTextProvider.java
+++ b/src/main/java/org/threeten/bp/format/DateTimeTextProvider.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map.Entry;
 
+import org.threeten.bp.jdk8.Jdk8Methods;
 import org.threeten.bp.temporal.TemporalField;
 
 /**
@@ -68,6 +69,25 @@ abstract class DateTimeTextProvider {
             }
         }
         return result;
+    }
+
+    /**
+     * Sets the provider to use.
+     * <p>
+     * This can only be called once and before the first call to {@link #getInstance()}.
+     *
+     * @param provider the provider to use, not null
+     * @throws IllegalStateException if provider is already set
+     */
+    static void setInstance(DateTimeTextProvider provider) {
+        Jdk8Methods.requireNonNull(provider, "provider");
+
+        synchronized (LOCK) {
+            if (INSTANCE != null) {
+                throw new IllegalStateException("Instance is already set");
+            }
+            INSTANCE = provider;
+        }
     }
 
     /**

--- a/src/main/java/org/threeten/bp/format/SimpleDateTimeTextProvider.java
+++ b/src/main/java/org/threeten/bp/format/SimpleDateTimeTextProvider.java
@@ -66,9 +66,6 @@ import org.threeten.bp.temporal.TemporalField;
 final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
      // TODO: Better implementation based on CLDR
 
-    /** Cache. */
-    private static final ConcurrentMap<Entry<TemporalField, Locale>, Object> CACHE =
-        new ConcurrentHashMap<Entry<TemporalField, Locale>, Object>(16, 0.75f, 2);
     /** Comparator. */
     private static final Comparator<Entry<String, Long>> COMPARATOR = new Comparator<Entry<String, Long>>() {
         @Override
@@ -76,6 +73,10 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
             return obj2.getKey().length() - obj1.getKey().length();  // longest to shortest
         }
     };
+
+    /** Cache. */
+    private final ConcurrentMap<Entry<TemporalField, Locale>, Object> cache =
+            new ConcurrentHashMap<Entry<TemporalField, Locale>, Object>(16, 0.75f, 2);
 
     //-----------------------------------------------------------------------
     /** {@inheritDoc} */
@@ -106,11 +107,11 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
     //-----------------------------------------------------------------------
     private Object findStore(TemporalField field, Locale locale) {
         Entry<TemporalField, Locale> key = createEntry(field, locale);
-        Object store = CACHE.get(key);
+        Object store = cache.get(key);
         if (store == null) {
             store = createStore(field, locale);
-            CACHE.putIfAbsent(key, store);
-            store = CACHE.get(key);
+            cache.putIfAbsent(key, store);
+            store = cache.get(key);
         }
         return store;
     }


### PR DESCRIPTION
This can solve #69 
Dependent libraries can use DateTimeTextProvider.setInstance() to set their implementation of DateTimeTextProvider as default.
As a side effect, if default instance is not set explicitly, only one instance of SimpleDateTimeTextProvider will be created.