### PR TITLE
Fix parsing a datetime with zone and offset

### DIFF
--- a/src/main/java/org/threeten/bp/format/DateTimeBuilder.java
+++ b/src/main/java/org/threeten/bp/format/DateTimeBuilder.java
@@ -614,16 +614,14 @@ final class DateTimeBuilder
 
     private void resolveInstant() {
         if (date != null && time != null) {
-            if (zone != null) {
+            Long offsetSecs = fieldValues.get(OFFSET_SECONDS);
+            if (offsetSecs != null) {
+                ZoneOffset offset = ZoneOffset.ofTotalSeconds(offsetSecs.intValue());
+                long instant = date.atTime(time).atZone(offset).getLong(ChronoField.INSTANT_SECONDS);
+                fieldValues.put(INSTANT_SECONDS, instant);
+            }  else if (zone != null) {
                 long instant = date.atTime(time).atZone(zone).getLong(ChronoField.INSTANT_SECONDS);
                 fieldValues.put(INSTANT_SECONDS, instant);
-            } else {
-                Long offsetSecs = fieldValues.get(OFFSET_SECONDS);
-                if (offsetSecs != null) {
-                    ZoneOffset offset = ZoneOffset.ofTotalSeconds(offsetSecs.intValue());
-                    long instant = date.atTime(time).atZone(offset).getLong(ChronoField.INSTANT_SECONDS);
-                    fieldValues.put(INSTANT_SECONDS, instant);
-                }
             }
         }
     }

--- a/src/test/java/org/threeten/bp/TestZonedDateTime.java
+++ b/src/test/java/org/threeten/bp/TestZonedDateTime.java
@@ -696,6 +696,47 @@ public class TestZonedDateTime extends AbstractDateTimeTest {
         ZonedDateTime.parse((String) null);
     }
 
+    @DataProvider(name="parseOverlapRoundtrip")
+    Object[][] data_parseOverlapRoundtrip() {
+        return new Object[][] {
+                {"2016-11-06T01:00-04:00[America/New_York]"},
+                {"2016-10-30T02:00+02:00[Europe/Berlin]"},
+        };
+    }
+
+    @Test(dataProvider="parseOverlapRoundtrip")
+    public void test_parseFormatRoundtripWithZoneAndOffset(String text) {
+        ZonedDateTime start = ZonedDateTime.parse(text);
+        for (int min=0; min <= 60; min += 15) {
+            ZonedDateTime  t = start.plusMinutes(min);
+            assertEquals(t, ZonedDateTime.parse(t.toString()));
+        }
+    }
+
+    @DataProvider(name="parseOverlapToInstant")
+    Object[][] data_parseOverlapToInstant() {
+        return new Object[][] {
+            {"2016-11-06T01:00-04:00[America/New_York]", "2016-11-06T05:00:00Z"},
+            {"2016-11-06T01:30-04:00[America/New_York]", "2016-11-06T05:30:00Z"},
+            {"2016-11-06T01:00-05:00[America/New_York]", "2016-11-06T06:00:00Z"},
+            {"2016-11-06T01:30-05:00[America/New_York]", "2016-11-06T06:30:00Z"},
+            {"2016-11-06T02:00-05:00[America/New_York]", "2016-11-06T07:00:00Z"},
+
+            {"2016-10-30T02:00+02:00[Europe/Berlin]", "2016-10-30T00:00:00Z"},
+            {"2016-10-30T02:30+02:00[Europe/Berlin]", "2016-10-30T00:30:00Z"},
+            {"2016-10-30T02:00+01:00[Europe/Berlin]", "2016-10-30T01:00:00Z"},
+            {"2016-10-30T02:30+01:00[Europe/Berlin]", "2016-10-30T01:30:00Z"},
+            {"2016-10-30T03:00+01:00[Europe/Berlin]", "2016-10-30T02:00:00Z"},
+        };
+    }
+
+    @Test(dataProvider="parseOverlapToInstant")
+    public void test_parseWithZoneAndOffsetToInstant(String z, String i) {
+        ZonedDateTime zdt = ZonedDateTime.parse(z);
+        Instant instant = Instant.parse(i);
+        assertEquals(zdt.toInstant(), instant);
+    }
+
     //-----------------------------------------------------------------------
     // parse(DateTimeFormatter)
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Attempt to fix issue #73, parsing a date-time string with zone and offset during an overlap dst. 

The fix making the offset always take priority as proposed in the bug ticket. If the offset is invalid change the local time to make the result valid.

I didn't look at the openJDK implementation, fixed it in a similar way in the downstream javascript project [js-joda](https://github.com/js-joda/js-joda). But i read the discussion in the bug ticket JDK-8066982, i hope that's not a license conflict already.