### PR TITLE
Restore tests to parse instant with offset seconds

### DIFF
--- a/src/test/java/org/threeten/bp/format/TestDateTimeParsing.java
+++ b/src/test/java/org/threeten/bp/format/TestDateTimeParsing.java
@@ -86,10 +86,10 @@ public class TestDateTimeParsing {
     private static final DateTimeFormatter INSTANTSECONDS_NOS_WITH_PARIS = INSTANTSECONDS_NOS.withZone(PARIS);
     private static final DateTimeFormatter INSTANTSECONDS_OFFSETSECONDS = new DateTimeFormatterBuilder()
         .appendValue(INSTANT_SECONDS).appendLiteral(' ').appendValue(OFFSET_SECONDS).toFormatter();
-//    private static final DateTimeFormatter INSTANT_OFFSETSECONDS_ZONE = new DateTimeFormatterBuilder()
-//            .appendInstant().appendLiteral(' ')
-//            .appendValue(OFFSET_SECONDS).appendLiteral(' ')
-//            .appendZoneId().toFormatter();
+    private static final DateTimeFormatter INSTANT_OFFSETSECONDS_ZONE = new DateTimeFormatterBuilder()
+        .appendInstant().appendLiteral(' ')
+        .appendValue(OFFSET_SECONDS).appendLiteral(' ')
+        .appendZoneId().toFormatter();
 
     @DataProvider(name = "instantZones")
     Object[][] data_instantZones() {
@@ -106,10 +106,10 @@ public class TestDateTimeParsing {
             {INSTANTSECONDS_WITH_PARIS, "86402", Instant.ofEpochSecond(86402).atZone(PARIS)},
             {INSTANTSECONDS_NOS_WITH_PARIS, "86402.123456789", Instant.ofEpochSecond(86402, 123456789).atZone(PARIS)},
             {INSTANTSECONDS_OFFSETSECONDS, "86402 9000", Instant.ofEpochSecond(86402).atZone(OFFSET_0230)},
-//            {INSTANT_OFFSETSECONDS_ZONE, "2016-10-30T00:30:00Z 7200 Europe/Paris",
-//                ZonedDateTime.ofStrict(LocalDateTime.of(2016, 10, 30, 2, 30), ZoneOffset.ofHours(2), PARIS)},
-//            {INSTANT_OFFSETSECONDS_ZONE, "2016-10-30T01:30:00Z 3600 Europe/Paris",
-//                    ZonedDateTime.ofStrict(LocalDateTime.of(2016, 10, 30, 2, 30), ZoneOffset.ofHours(1), PARIS)},
+            {INSTANT_OFFSETSECONDS_ZONE, "2016-10-30T00:30:00Z 7200 Europe/Paris",
+                ZonedDateTime.ofStrict(LocalDateTime.of(2016, 10, 30, 2, 30), ZoneOffset.ofHours(2), PARIS)},
+            {INSTANT_OFFSETSECONDS_ZONE, "2016-10-30T01:30:00Z 3600 Europe/Paris",
+                ZonedDateTime.ofStrict(LocalDateTime.of(2016, 10, 30, 2, 30), ZoneOffset.ofHours(1), PARIS)},
         };
     }
 


### PR DESCRIPTION
Issue #53 notes the addition of tests for bugs reported at OpenJDK. Some of these were commented out pending a future fix. Failure of these tests was resolved in PR 77 with the issue #73 fix. This PR restores these (now passing) tests.

As far as I can see, that means all tests added for #53 now pass, which suggests that the issue may be closed.