### PR TITLE
Javadoc refactoring

### DIFF
--- a/src/main/java/org/threeten/bp/Instant.java
+++ b/src/main/java/org/threeten/bp/Instant.java
@@ -349,7 +349,7 @@ public final class Instant
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@code Instant} from a text string such as
-     * {@code 2007-12-03T10:15:30.000Z}.
+     * {@code 2007-12-23T10:15:30.000Z}.
      * <p>
      * The string must represent a valid instant in UTC and is parsed using
      * {@link DateTimeFormatter#ISO_INSTANT}.

--- a/src/main/java/org/threeten/bp/LocalDate.java
+++ b/src/main/java/org/threeten/bp/LocalDate.java
@@ -75,7 +75,7 @@ import org.threeten.bp.zone.ZoneRules;
 
 /**
  * A date without a time-zone in the ISO-8601 calendar system,
- * such as {@code 2007-12-03}.
+ * such as {@code 2007-12-23}.
  * <p>
  * {@code LocalDate} is an immutable date-time object that represents a date,
  * often viewed as year-month-day. Other date fields, such as day-of-year,
@@ -339,12 +339,12 @@ public final class LocalDate
 
     //-----------------------------------------------------------------------
     /**
-     * Obtains an instance of {@code LocalDate} from a text string such as {@code 2007-12-03}.
+     * Obtains an instance of {@code LocalDate} from a text string such as {@code 2007-12-23}.
      * <p>
      * The string must represent a valid date and is parsed using
      * {@link org.threeten.bp.format.DateTimeFormatter#ISO_LOCAL_DATE}.
      *
-     * @param text  the text to parse such as "2007-12-03", not null
+     * @param text  the text to parse such as "2007-12-23", not null
      * @return the parsed local date, not null
      * @throws DateTimeParseException if the text cannot be parsed
      */
@@ -1812,7 +1812,7 @@ public final class LocalDate
 
     //-----------------------------------------------------------------------
     /**
-     * Outputs this date as a {@code String}, such as {@code 2007-12-03}.
+     * Outputs this date as a {@code String}, such as {@code 2007-12-23}.
      * <p>
      * The output will be in the ISO-8601 format {@code yyyy-MM-dd}.
      *

--- a/src/main/java/org/threeten/bp/LocalDateTime.java
+++ b/src/main/java/org/threeten/bp/LocalDateTime.java
@@ -69,7 +69,7 @@ import org.threeten.bp.zone.ZoneRules;
 
 /**
  * A date-time without a time-zone in the ISO-8601 calendar system,
- * such as {@code 2007-12-03T10:15:30}.
+ * such as {@code 2007-12-23T10:15:30}.
  * <p>
  * {@code LocalDateTime} is an immutable date-time object that represents a date-time,
  * often viewed as year-month-day-hour-minute-second. Other date and time fields,
@@ -416,12 +416,12 @@ public final class LocalDateTime
 
     //-----------------------------------------------------------------------
     /**
-     * Obtains an instance of {@code LocalDateTime} from a text string such as {@code 2007-12-03T10:15:30}.
+     * Obtains an instance of {@code LocalDateTime} from a text string such as {@code 2007-12-23T10:15:30}.
      * <p>
      * The string must represent a valid date-time and is parsed using
      * {@link org.threeten.bp.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME}.
      *
-     * @param text  the text to parse such as "2007-12-03T10:15:30", not null
+     * @param text  the text to parse such as "2007-12-23T10:15:30", not null
      * @return the parsed local date-time, not null
      * @throws DateTimeParseException if the text cannot be parsed
      */
@@ -1793,7 +1793,7 @@ public final class LocalDateTime
 
     //-----------------------------------------------------------------------
     /**
-     * Outputs this date-time as a {@code String}, such as {@code 2007-12-03T10:15:30}.
+     * Outputs this date-time as a {@code String}, such as {@code 2007-12-23T10:15:30}.
      * <p>
      * The output will be one of the following ISO-8601 formats:
      * <p><ul>

--- a/src/main/java/org/threeten/bp/OffsetDateTime.java
+++ b/src/main/java/org/threeten/bp/OffsetDateTime.java
@@ -66,7 +66,7 @@ import org.threeten.bp.zone.ZoneRules;
 
 /**
  * A date-time with an offset from UTC/Greenwich in the ISO-8601 calendar system,
- * such as {@code 2007-12-03T10:15:30+01:00}.
+ * such as {@code 2007-12-23T10:15:30+01:00}.
  * <p>
  * {@code OffsetDateTime} is an immutable representation of a date-time with an offset.
  * This class stores all date and time fields, to a precision of nanoseconds,
@@ -331,12 +331,12 @@ public final class OffsetDateTime
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@code OffsetDateTime} from a text string
-     * such as {@code 2007-12-03T10:15:30+01:00}.
+     * such as {@code 2007-12-23T10:15:30+01:00}.
      * <p>
      * The string must represent a valid date-time and is parsed using
      * {@link org.threeten.bp.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME}.
      *
-     * @param text  the text to parse such as "2007-12-03T10:15:30+01:00", not null
+     * @param text  the text to parse such as "2007-12-23T10:15:30+01:00", not null
      * @return the parsed offset date-time, not null
      * @throws DateTimeParseException if the text cannot be parsed
      */
@@ -571,8 +571,8 @@ public final class OffsetDateTime
      * <p>
      * This method returns an object with the same {@code LocalDateTime} and the specified {@code ZoneOffset}.
      * No calculation is needed or performed.
-     * For example, if this time represents {@code 2007-12-03T10:30+02:00} and the offset specified is
-     * {@code +03:00}, then this method will return {@code 2007-12-03T10:30+03:00}.
+     * For example, if this time represents {@code 2007-12-23T10:30+02:00} and the offset specified is
+     * {@code +03:00}, then this method will return {@code 2007-12-23T10:30+03:00}.
      * <p>
      * To take into account the difference between the offsets, and adjust the time fields,
      * use {@link #withOffsetSameInstant}.
@@ -594,8 +594,8 @@ public final class OffsetDateTime
      * adjusted by the difference between the two offsets.
      * This will result in the old and new objects representing the same instant.
      * This is useful for finding the local time in a different offset.
-     * For example, if this time represents {@code 2007-12-03T10:30+02:00} and the offset specified is
-     * {@code +03:00}, then this method will return {@code 2007-12-03T11:30+03:00}.
+     * For example, if this time represents {@code 2007-12-23T10:30+02:00} and the offset specified is
+     * {@code +03:00}, then this method will return {@code 2007-12-23T11:30+03:00}.
      * <p>
      * To change the offset without adjusting the local time use {@link #withOffsetSameLocal}.
      * <p>
@@ -1756,7 +1756,7 @@ public final class OffsetDateTime
 
     //-----------------------------------------------------------------------
     /**
-     * Outputs this date-time as a {@code String}, such as {@code 2007-12-03T10:15:30+01:00}.
+     * Outputs this date-time as a {@code String}, such as {@code 2007-12-23T10:15:30+01:00}.
      * <p>
      * The output will be one of the following ISO-8601 formats:
      * <p><ul>

--- a/src/main/java/org/threeten/bp/ZonedDateTime.java
+++ b/src/main/java/org/threeten/bp/ZonedDateTime.java
@@ -65,7 +65,7 @@ import org.threeten.bp.zone.ZoneRules;
 
 /**
  * A date-time with a time-zone in the ISO-8601 calendar system,
- * such as {@code 2007-12-03T10:15:30+01:00 Europe/Paris}.
+ * such as {@code 2007-12-23T10:15:30+01:00 Europe/Paris}.
  * <p>
  * {@code ZonedDateTime} is an immutable representation of a date-time with a time-zone.
  * This class stores all date and time fields, to a precision of nanoseconds,
@@ -534,12 +534,12 @@ public final class ZonedDateTime
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@code ZonedDateTime} from a text string such as
-     * {@code 2007-12-03T10:15:30+01:00[Europe/Paris]}.
+     * {@code 2007-12-23T10:15:30+01:00[Europe/Paris]}.
      * <p>
      * The string must represent a valid date-time and is parsed using
      * {@link org.threeten.bp.format.DateTimeFormatter#ISO_ZONED_DATE_TIME}.
      *
-     * @param text  the text to parse such as "2007-12-03T10:15:30+01:00[Europe/Paris]", not null
+     * @param text  the text to parse such as "2007-12-23T10:15:30+01:00[Europe/Paris]", not null
      * @return the parsed zoned date-time, not null
      * @throws DateTimeParseException if the text cannot be parsed
      */
@@ -2064,7 +2064,7 @@ public final class ZonedDateTime
     //-----------------------------------------------------------------------
     /**
      * Outputs this date-time as a {@code String}, such as
-     * {@code 2007-12-03T10:15:30+01:00[Europe/Paris]}.
+     * {@code 2007-12-23T10:15:30+01:00[Europe/Paris]}.
      * <p>
      * The format consists of the {@code LocalDateTime} followed by the {@code ZoneOffset}.
      * If the {@code ZoneId} is not the same as the offset, then the ID is output.


### PR DESCRIPTION
For avoiding misunderstanding when you reading javadoc I suggest change 2007-12-03 to 2007-12-23.

Because YYYY-MM-DD and YYYY-DD-MM will be matched for 2007-12-03. But when you will see 2007-12-23 you will immediately get that date format is YYYY-MM-DD.