### PR TITLE
Add R8/ProGuard rules to retain Ser constructor

### DIFF
--- a/src/main/resources/META-INF/proguard/org.threeten.bp.pro
+++ b/src/main/resources/META-INF/proguard/org.threeten.bp.pro
@@ -1,0 +1,3 @@
+-keepclassmembers class org.threeten.bp.Ser {
+  <init>();
+}


### PR DESCRIPTION
This is invoked reflectively per the Externalizable contract and must not be removed.

Closes #120 