### PR TITLE
Remove unused HashMap's in ThaiBuddhistChronology

### DIFF
--- a/src/main/java/org/threeten/bp/chrono/ThaiBuddhistChronology.java
+++ b/src/main/java/org/threeten/bp/chrono/ThaiBuddhistChronology.java
@@ -51,7 +51,6 @@ import static org.threeten.bp.temporal.TemporalAdjusters.nextOrSame;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -110,41 +109,6 @@ public final class ThaiBuddhistChronology extends Chronology implements Serializ
      * Containing the offset to add to the ISO year.
      */
     static final int YEARS_DIFFERENCE = 543;
-    /**
-     * Narrow names for eras.
-     */
-    private static final HashMap<String, String[]> ERA_NARROW_NAMES = new HashMap<String, String[]>();
-    /**
-     * Short names for eras.
-     */
-    private static final HashMap<String, String[]> ERA_SHORT_NAMES = new HashMap<String, String[]>();
-    /**
-     * Full names for eras.
-     */
-    private static final HashMap<String, String[]> ERA_FULL_NAMES = new HashMap<String, String[]>();
-    /**
-     * Fallback language for the era names.
-     */
-    private static final String FALLBACK_LANGUAGE = "en";
-    /**
-     * Language that has the era names.
-     */
-    private static final String TARGET_LANGUAGE = "th";
-    /**
-     * Name data.
-     */
-    static {
-        ERA_NARROW_NAMES.put(FALLBACK_LANGUAGE, new String[]{"BB", "BE"});
-        ERA_NARROW_NAMES.put(TARGET_LANGUAGE, new String[]{"BB", "BE"});
-        ERA_SHORT_NAMES.put(FALLBACK_LANGUAGE, new String[]{"B.B.", "B.E."});
-        ERA_SHORT_NAMES.put(TARGET_LANGUAGE,
-                new String[]{"\u0e1e.\u0e28.",
-                "\u0e1b\u0e35\u0e01\u0e48\u0e2d\u0e19\u0e04\u0e23\u0e34\u0e2a\u0e15\u0e4c\u0e01\u0e32\u0e25\u0e17\u0e35\u0e48"});
-        ERA_FULL_NAMES.put(FALLBACK_LANGUAGE, new String[]{"Before Buddhist", "Budhhist Era"});
-        ERA_FULL_NAMES.put(TARGET_LANGUAGE,
-                new String[]{"\u0e1e\u0e38\u0e17\u0e18\u0e28\u0e31\u0e01\u0e23\u0e32\u0e0a",
-                "\u0e1b\u0e35\u0e01\u0e48\u0e2d\u0e19\u0e04\u0e23\u0e34\u0e2a\u0e15\u0e4c\u0e01\u0e32\u0e25\u0e17\u0e35\u0e48"});
-    }
 
     /**
      * Restricted constructor.


### PR DESCRIPTION
I've noticed 3 unused static HashMap's in ThaiBuddhistChronology.
See https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-September/081866.html