### PR TITLE
Update deployment from OSSRH

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -4,13 +4,13 @@
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>sonatype-threeten-staging</id>
-      <username>${env.OSSRH_USERNAME}</username>
-      <password>${env.OSSRH_TOKEN}</password>
+      <id>central-publish</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
     </server>
     <server>
       <id>github</id>
-      <privateKey>${env.GITHUB_TOKEN}</privateKey>
+      <password>${env.GITHUB_TOKEN}</password>
     </server>
   </servers>
 </settings>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - 'main'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -23,14 +23,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-        fetch-tags: true
-
-    - name: Setup git
-      run: |
-        git config --global user.name "Stephen Colebourne (CI)"
-        git config --global user.email "scolebourne@joda.org"
 
     - name: Set up JDK
       uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
 
     - name: Maven release
       env:
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
         MAVEN_GPG_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
         GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+        ref: ${{ github.ref }}
         fetch-tags: true
 
     - name: Setup git

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ Tidelift will coordinate the fix and disclosure.
 
 Release from local:
 
-* Turn off gpg "bc" signer
+* Ensure `gpg-agent` is running
 * `mvn clean release:clean release:prepare release:perform`

--- a/pom.xml
+++ b/pom.xml
@@ -593,24 +593,6 @@
   </reporting>
 
   <!-- ==================================================================== -->
-  <distributionManagement>
-    <repository>
-      <id>sonatype-threeten-staging</id>
-      <name>Sonatype OSS staging repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      <layout>default</layout>
-    </repository>
-    <snapshotRepository>
-      <uniqueVersion>false</uniqueVersion>
-      <id>sonatype-threeten-snapshot</id>
-      <name>Sonatype OSS snapshot repository</name>
-      <url>https://oss.sonatype.org/content/repositories/threeten-snapshots</url>
-      <layout>default</layout>
-    </snapshotRepository>
-    <downloadUrl>https://oss.sonatype.org/content/repositories/threeten-releases</downloadUrl>
-  </distributionManagement>
-
-  <!-- ==================================================================== -->
   <profiles>
     <!-- Setup for Java 9+ -->
     <profile>
@@ -658,6 +640,19 @@
         </plugins>
       </build>
     </profile>
+    <!-- Set environment when running on GitHub Actions -->
+    <profile>
+      <id>github-action</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <gpg.signer>bc</gpg.signer>
+      </properties>
+    </profile>
     <!-- Deployment profile, activated by -Doss.repo -->
     <profile>
       <id>release-artifacts</id>
@@ -699,9 +694,6 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <configuration>
-                  <signer>bc</signer>
-                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -728,18 +720,17 @@
               </execution>
             </executions>
           </plugin>
-          <!-- Use nexus plugin to directly release -->
+          <!-- Use central plugin to directly release -->
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <serverId>sonatype-threeten-staging</serverId>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-              <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
+              <publishingServerId>central-publish</publishingServerId>
+              <deploymentName>${project.name}</deploymentName>
+              <autoPublish>${joda.publish.auto}</autoPublish>
+              <waitUntil>${joda.publish.wait}</waitUntil>
             </configuration>
           </plugin>
         </plugins>
@@ -849,9 +840,9 @@
     <maven-surefire-report-plugin.version>3.0.0-M7</maven-surefire-report-plugin.version>
     <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
     <!-- Other plugins -->
+    <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
     <github-api.version>1.314</github-api.version>
     <github-release-plugin.version>1.4.0</github-release-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <reflow-velocity-tools.version>1.2</reflow-velocity-tools.version>
     <!-- Properties for maven-compiler-plugin -->
     <maven.compiler.compilerVersion>1.6</maven.compiler.compilerVersion>
@@ -867,6 +858,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <linkXRef>false</linkXRef>
+    <joda.publish.auto>true</joda.publish.auto><!-- false/true -->
+    <joda.publish.wait>published</joda.publish.wait><!-- validated/published -->
     <tz.database.version>2025bgtz</tz.database.version>
   </properties>
 </project>


### PR DESCRIPTION
OSSRH is dead, use replacement
Match setup in other projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated releases to Maven Central’s modern publishing flow and removed legacy staging configuration.
  * Tightened CI permissions and removed unnecessary git setup for improved security.
  * Standardized credentials for publishing and GitHub interactions.
  * Ensured website builds deploy from the exact triggering branch or tag.
  * Improved CI signing configuration for more reliable automated releases.
* **Documentation**
  * Updated local release instructions to ensure gpg-agent is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->