### PR TITLE
Prepare for release v1.7.5

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,6 +8,16 @@
   <body>
 
     <!-- types are add, fix, remove, update -->
+
+    <release version="1.7.5" date="2026-07-26" description="v1.7.5">
+
+      <action dev="jodastephen" type="update">
+
+        Prepare release 1.7.5.
+
+      </action>
+
+    </release>
     <release version="1.7.4" date="2026-07-26" description="v1.7.4">
       <action dev="jodastephen" type="update">
         Update to time-zone data 2026cgtz.

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -43,7 +43,7 @@ Various documentation is available:
 
 ## <i></i> Releases
 
-Release 1.7.4 is the latest release.
+Release 1.7.5 is the latest release.
 It is considered to be stable and usable in production.
 
 The project runs on Java SE 6 (or later) and has no [dependencies](dependencies.html).
@@ -59,7 +59,7 @@ Available in [Maven Central](https://search.maven.org/search?q=g:org.threeten%20
 <dependency>
   <groupId>org.threeten</groupId>
   <artifactId>threetenbp</artifactId>
-  <version>1.7.4</version>
+  <version>1.7.5</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Prepare for release v1.7.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation to identify version 1.7.5 as the latest release.
  * Updated the Maven Central dependency example to use version 1.7.5.
  * Added release notes for version 1.7.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->